### PR TITLE
fix(tools): listen to nodemon quit event to exit the process 

### DIFF
--- a/tools/dev-server.js
+++ b/tools/dev-server.js
@@ -13,7 +13,8 @@ const project = require('../package.json').name;
     tunnel({ port, project });
 
     process.env.PORT = port;
-    nodemon('index.js');
+    const server = nodemon('index.js');
+    server.on('quit', () => process.exit());
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
**Issue**
When using `ctrl + c` after running `yarn dev` to close the spawned node server it throws the following error:
```
events.js:292                                                                                                                                                                                                                                                         
      throw er; // Unhandled 'error' event
      ^

Error: read EIO
    at TTY.onStreamRead (internal/stream_base_commons.js:205:27)
Emitted 'error' event on ReadStream instance at:
    at emitErrorNT (internal/streams/destroy.js:92:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:60:3)
    at processTicksAndRejections (internal/process/task_queues.js:84:21) {
  errno: 'EIO',
  code: 'EIO',
  syscall: 'read'
}
```

**Solution**
adding an event listener that listens to the `close` event of `nodemon` allows for exiting the node process cleanly and prevent the error above.